### PR TITLE
Cameraの中のCameraManager.csを、新規作成した空のゲームオブジェクトに移動させた。

### DIFF
--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -250,12 +250,12 @@ MonoBehaviour:
   m_RequiresColorTexture: 0
   m_Version: 2
   m_TaaSettings:
-    quality: 3
-    frameInfluence: 0.1
-    jitterScale: 1
-    mipBias: 0
-    varianceClampScale: 0.9
-    contrastAdaptiveSharpening: 0
+    m_Quality: 3
+    m_FrameInfluence: 0.1
+    m_JitterScale: 1
+    m_MipBias: 0
+    m_VarianceClampScale: 0.9
+    m_ContrastAdaptiveSharpening: 0
 --- !u!114 &4673857090115547090
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -270,9 +270,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   player: {fileID: 6197523301108723743}
   enemy: {fileID: 0}
-  skyEnemy: {fileID: 0}
+  skyEnemy:
+  - {fileID: 0}
   player_obj: {fileID: 5847142556975503699}
   enemy_obj: {fileID: 0}
+  tipsTextKey: {fileID: 0}
   tipsText: {fileID: 0}
   MissionText: {fileID: 0}
   clearText: {fileID: 0}
@@ -433,6 +435,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   attractor: {fileID: 0}
+  enemy: {fileID: 0}
   healthbar: {fileID: 0}
   hptext: {fileID: 0}
   gameovertext: {fileID: 0}
@@ -440,6 +443,8 @@ MonoBehaviour:
   hp: 100
   movespeed: 10
   groundflg: 0
+  hpflg: 0
+  moveflg: 0
 --- !u!1001 &4465371035737828441
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -522,6 +527,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: Leaf
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: fc38eb1d15aad094cafb3cb0e7542241,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -616,6 +626,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: Sprout
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: be4fadb40c54934419fd624cd0021acf,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Scenes/GameScene1.unity
+++ b/Assets/Scenes/GameScene1.unity
@@ -447,7 +447,8 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 4673857090115547090, guid: 15b44400035ffbd4a8e523515c25e0cd, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -814,6 +815,63 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 1953897288}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1723136990
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1723136992}
+  - component: {fileID: 1723136991}
+  m_Layer: 0
+  m_Name: GameObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1723136991
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1723136990}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5544a84e1daa73c46b48dbc69f889ac4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  player: {fileID: 1861806872}
+  enemy: {fileID: 7960315578906518100, guid: 8d293bab74173f64c887a5e2071ba933, type: 3}
+  skyEnemy:
+  - {fileID: 0}
+  player_obj: {fileID: 1861806871}
+  enemy_obj: {fileID: 1851169568}
+  tipsTextKey: {fileID: 2143390444}
+  tipsText: {fileID: 905790617}
+  MissionText: {fileID: 4749342092388139652}
+  clearText: {fileID: 887773449297920791}
+  gameOverText: {fileID: 6641713546989135716}
+  timeText: {fileID: 5631483522072484241}
+  countdown: 60
+--- !u!4 &1723136992
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1723136990}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1851169568 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 5924863072519430230, guid: 8d293bab74173f64c887a5e2071ba933,
@@ -2035,3 +2093,4 @@ SceneRoots:
   - {fileID: 1953897288}
   - {fileID: 1961592270}
   - {fileID: 1076285391}
+  - {fileID: 1723136992}

--- a/Assets/Scenes/GameScene2.unity
+++ b/Assets/Scenes/GameScene2.unity
@@ -603,6 +603,64 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 7691997649379579761}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1588773700
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1588773702}
+  - component: {fileID: 1588773701}
+  m_Layer: 0
+  m_Name: GameObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1588773701
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1588773700}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5544a84e1daa73c46b48dbc69f889ac4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  player: {fileID: 1940283756}
+  enemy: {fileID: 7960315578906518100, guid: 8d293bab74173f64c887a5e2071ba933, type: 3}
+  skyEnemy:
+  - {fileID: 0}
+  player_obj: {fileID: 1321993647}
+  enemy_obj: {fileID: 5924863072519430230, guid: 8d293bab74173f64c887a5e2071ba933,
+    type: 3}
+  tipsTextKey: {fileID: 1106595954}
+  tipsText: {fileID: 707284830}
+  MissionText: {fileID: 154984451}
+  clearText: {fileID: 1802199713}
+  gameOverText: {fileID: 1051960243}
+  timeText: {fileID: 2036562634}
+  countdown: 60
+--- !u!4 &1588773702
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1588773700}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1802199710 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 4610033774324062524, guid: 2c9fa19d423659c43b475aec31b4abfc,
@@ -619,18 +677,6 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &1820601435 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 4673857090115547090, guid: 15b44400035ffbd4a8e523515c25e0cd,
-    type: 3}
-  m_PrefabInstance: {fileID: 7691997649379579761}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5544a84e1daa73c46b48dbc69f889ac4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &1872243273
@@ -1405,7 +1451,8 @@ PrefabInstance:
       propertyPath: healthbar
       value: 
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 4673857090115547090, guid: 15b44400035ffbd4a8e523515c25e0cd, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents:
@@ -1509,6 +1556,11 @@ PrefabInstance:
       objectReference: {fileID: 1940283756}
     - target: {fileID: 117005818533803431, guid: 567347007592d07468c8d8aad25dcb19,
         type: 3}
+      propertyPath: timeText
+      value: 
+      objectReference: {fileID: 2036562634}
+    - target: {fileID: 117005818533803431, guid: 567347007592d07468c8d8aad25dcb19,
+        type: 3}
       propertyPath: damegetext
       value: 
       objectReference: {fileID: 145341026}
@@ -1516,7 +1568,7 @@ PrefabInstance:
         type: 3}
       propertyPath: cameraManager
       value: 
-      objectReference: {fileID: 1820601435}
+      objectReference: {fileID: 0}
     - target: {fileID: 362927176130508445, guid: 567347007592d07468c8d8aad25dcb19,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -1574,6 +1626,11 @@ PrefabInstance:
       objectReference: {fileID: 1940283756}
     - target: {fileID: 1039206927326321828, guid: 567347007592d07468c8d8aad25dcb19,
         type: 3}
+      propertyPath: timeText
+      value: 
+      objectReference: {fileID: 2036562634}
+    - target: {fileID: 1039206927326321828, guid: 567347007592d07468c8d8aad25dcb19,
+        type: 3}
       propertyPath: damegetext
       value: 
       objectReference: {fileID: 145341026}
@@ -1581,12 +1638,17 @@ PrefabInstance:
         type: 3}
       propertyPath: cameraManager
       value: 
-      objectReference: {fileID: 1820601435}
+      objectReference: {fileID: 0}
     - target: {fileID: 1435633644999899867, guid: 567347007592d07468c8d8aad25dcb19,
         type: 3}
       propertyPath: player
       value: 
       objectReference: {fileID: 1940283756}
+    - target: {fileID: 1435633644999899867, guid: 567347007592d07468c8d8aad25dcb19,
+        type: 3}
+      propertyPath: timeText
+      value: 
+      objectReference: {fileID: 2036562634}
     - target: {fileID: 1435633644999899867, guid: 567347007592d07468c8d8aad25dcb19,
         type: 3}
       propertyPath: damegetext
@@ -1596,12 +1658,17 @@ PrefabInstance:
         type: 3}
       propertyPath: cameraManager
       value: 
-      objectReference: {fileID: 1820601435}
+      objectReference: {fileID: 0}
     - target: {fileID: 3103654202958394723, guid: 567347007592d07468c8d8aad25dcb19,
         type: 3}
       propertyPath: player
       value: 
       objectReference: {fileID: 1940283756}
+    - target: {fileID: 3103654202958394723, guid: 567347007592d07468c8d8aad25dcb19,
+        type: 3}
+      propertyPath: timeText
+      value: 
+      objectReference: {fileID: 2036562634}
     - target: {fileID: 3103654202958394723, guid: 567347007592d07468c8d8aad25dcb19,
         type: 3}
       propertyPath: damegetext
@@ -1611,7 +1678,7 @@ PrefabInstance:
         type: 3}
       propertyPath: cameraManager
       value: 
-      objectReference: {fileID: 1820601435}
+      objectReference: {fileID: 0}
     - target: {fileID: 3808110960849004214, guid: 567347007592d07468c8d8aad25dcb19,
         type: 3}
       propertyPath: m_Name
@@ -1624,6 +1691,11 @@ PrefabInstance:
       objectReference: {fileID: 1940283756}
     - target: {fileID: 6530681076466333626, guid: 567347007592d07468c8d8aad25dcb19,
         type: 3}
+      propertyPath: timeText
+      value: 
+      objectReference: {fileID: 2036562634}
+    - target: {fileID: 6530681076466333626, guid: 567347007592d07468c8d8aad25dcb19,
+        type: 3}
       propertyPath: damegetext
       value: 
       objectReference: {fileID: 145341026}
@@ -1631,12 +1703,17 @@ PrefabInstance:
         type: 3}
       propertyPath: cameraManager
       value: 
-      objectReference: {fileID: 1820601435}
+      objectReference: {fileID: 0}
     - target: {fileID: 6953167321663598461, guid: 567347007592d07468c8d8aad25dcb19,
         type: 3}
       propertyPath: player
       value: 
       objectReference: {fileID: 1940283756}
+    - target: {fileID: 6953167321663598461, guid: 567347007592d07468c8d8aad25dcb19,
+        type: 3}
+      propertyPath: timeText
+      value: 
+      objectReference: {fileID: 2036562634}
     - target: {fileID: 6953167321663598461, guid: 567347007592d07468c8d8aad25dcb19,
         type: 3}
       propertyPath: damegetext
@@ -1646,12 +1723,17 @@ PrefabInstance:
         type: 3}
       propertyPath: cameraManager
       value: 
-      objectReference: {fileID: 1820601435}
+      objectReference: {fileID: 0}
     - target: {fileID: 8721076110584349702, guid: 567347007592d07468c8d8aad25dcb19,
         type: 3}
       propertyPath: player
       value: 
       objectReference: {fileID: 1940283756}
+    - target: {fileID: 8721076110584349702, guid: 567347007592d07468c8d8aad25dcb19,
+        type: 3}
+      propertyPath: timeText
+      value: 
+      objectReference: {fileID: 2036562634}
     - target: {fileID: 8721076110584349702, guid: 567347007592d07468c8d8aad25dcb19,
         type: 3}
       propertyPath: damegetext
@@ -1661,7 +1743,7 @@ PrefabInstance:
         type: 3}
       propertyPath: cameraManager
       value: 
-      objectReference: {fileID: 1820601435}
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -1682,3 +1764,4 @@ SceneRoots:
   - {fileID: 1084027105}
   - {fileID: 1959330948}
   - {fileID: 1021722941}
+  - {fileID: 1588773702}

--- a/Assets/Scenes/GameScene3.unity
+++ b/Assets/Scenes/GameScene3.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.019139495, g: 0.015756458, b: 0.051109675, a: 1}
+  m_IndirectSpecularColor: {r: 0.019140365, g: 0.01575535, b: 0.051104724, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -335,6 +335,11 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[1]
       value: 
       objectReference: {fileID: 2100000, guid: f2203f80845a66e4ab859ec6b767fcde, type: 2}
+    - target: {fileID: 3546943823860306184, guid: 15b44400035ffbd4a8e523515c25e0cd,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 4673857090115547090, guid: 15b44400035ffbd4a8e523515c25e0cd,
         type: 3}
       propertyPath: enemy
@@ -478,7 +483,8 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 4673857090115547090, guid: 15b44400035ffbd4a8e523515c25e0cd, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents:
@@ -620,18 +626,6 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 8539ca1f00b1ee34bbdc30d403594082, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &560440297 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 4673857090115547090, guid: 15b44400035ffbd4a8e523515c25e0cd,
-    type: 3}
-  m_PrefabInstance: {fileID: 168010964}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5544a84e1daa73c46b48dbc69f889ac4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!64 &625043661
@@ -814,7 +808,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   player: {fileID: 1822111154}
   scc: {fileID: 1176318368}
-  cameraManager: {fileID: 560440297}
+  cameraManager: {fileID: 1080861652}
   corePos: {fileID: 666692431}
   audioClip: {fileID: 8300000, guid: 764738ae8d75d9147b796d9b85558d3d, type: 3}
   rot: {x: 0, y: 0, z: 0, w: 0}
@@ -1079,6 +1073,69 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 1603546794}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1080861651
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1080861653}
+  - component: {fileID: 1080861652}
+  m_Layer: 0
+  m_Name: GameObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1080861652
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1080861651}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5544a84e1daa73c46b48dbc69f889ac4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  player: {fileID: 1822111154}
+  enemy: {fileID: 7960315578906518100, guid: 8d293bab74173f64c887a5e2071ba933, type: 3}
+  skyEnemy:
+  - {fileID: 430743997}
+  - {fileID: 5702947696258858111}
+  - {fileID: 5702947696258858110}
+  - {fileID: 5702947696258858109}
+  - {fileID: 5702947696258858108}
+  - {fileID: 5702947696258858107}
+  - {fileID: 5702947696258858106}
+  player_obj: {fileID: 168010965}
+  enemy_obj: {fileID: 1199147498}
+  tipsTextKey: {fileID: 1144577543570120827}
+  tipsText: {fileID: 1917216800}
+  MissionText: {fileID: 228249233}
+  clearText: {fileID: 983313691}
+  gameOverText: {fileID: 631187530}
+  timeText: {fileID: 2035928323}
+  countdown: 60
+--- !u!4 &1080861653
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1080861651}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1176318366 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 2572050229066182967, guid: a48a727c7065c3548ba40c77254c6b50,
@@ -1665,7 +1722,7 @@ PrefabInstance:
         type: 3}
       propertyPath: cameraManager
       value: 
-      objectReference: {fileID: 560440297}
+      objectReference: {fileID: 1080861652}
     - target: {fileID: 7509761686565556420, guid: a48a727c7065c3548ba40c77254c6b50,
         type: 3}
       propertyPath: scc
@@ -1964,7 +2021,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   player: {fileID: 1822111154}
   scc: {fileID: 402823196}
-  cameraManager: {fileID: 560440297}
+  cameraManager: {fileID: 1080861652}
   corePos: {fileID: 469634934}
   audioClip: {fileID: 8300000, guid: 764738ae8d75d9147b796d9b85558d3d, type: 3}
   rot: {x: 0, y: 0, z: 0, w: 0}
@@ -3606,3 +3663,4 @@ SceneRoots:
   - {fileID: 1750974983}
   - {fileID: 879560298}
   - {fileID: 1603546794}
+  - {fileID: 1080861653}

--- a/Assets/Scenes/GameScene4.unity
+++ b/Assets/Scenes/GameScene4.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.019139495, g: 0.015756458, b: 0.051109675, a: 1}
+  m_IndirectSpecularColor: {r: 0.019140365, g: 0.01575535, b: 0.051104724, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -847,7 +847,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   player: {fileID: 1940283756}
   scc: {fileID: 1982001578}
-  cameraManager: {fileID: 1388310083}
+  cameraManager: {fileID: 1960507846}
   corePos: {fileID: 542871335}
   audioClip: {fileID: 8300000, guid: 764738ae8d75d9147b796d9b85558d3d, type: 3}
   rot: {x: 0, y: 0, z: 0, w: 0}
@@ -969,6 +969,11 @@ PrefabInstance:
       objectReference: {fileID: 1940283756}
     - target: {fileID: 117005818533803431, guid: 567347007592d07468c8d8aad25dcb19,
         type: 3}
+      propertyPath: timeText
+      value: 
+      objectReference: {fileID: 1349068890}
+    - target: {fileID: 117005818533803431, guid: 567347007592d07468c8d8aad25dcb19,
+        type: 3}
       propertyPath: damegetext
       value: 
       objectReference: {fileID: 771972607}
@@ -976,7 +981,7 @@ PrefabInstance:
         type: 3}
       propertyPath: cameraManager
       value: 
-      objectReference: {fileID: 1388310083}
+      objectReference: {fileID: 0}
     - target: {fileID: 279849385889158267, guid: 567347007592d07468c8d8aad25dcb19,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -1084,6 +1089,11 @@ PrefabInstance:
       objectReference: {fileID: 1940283756}
     - target: {fileID: 1039206927326321828, guid: 567347007592d07468c8d8aad25dcb19,
         type: 3}
+      propertyPath: timeText
+      value: 
+      objectReference: {fileID: 1349068890}
+    - target: {fileID: 1039206927326321828, guid: 567347007592d07468c8d8aad25dcb19,
+        type: 3}
       propertyPath: damegetext
       value: 
       objectReference: {fileID: 771972607}
@@ -1091,12 +1101,17 @@ PrefabInstance:
         type: 3}
       propertyPath: cameraManager
       value: 
-      objectReference: {fileID: 1388310083}
+      objectReference: {fileID: 0}
     - target: {fileID: 1435633644999899867, guid: 567347007592d07468c8d8aad25dcb19,
         type: 3}
       propertyPath: player
       value: 
       objectReference: {fileID: 1940283756}
+    - target: {fileID: 1435633644999899867, guid: 567347007592d07468c8d8aad25dcb19,
+        type: 3}
+      propertyPath: timeText
+      value: 
+      objectReference: {fileID: 1349068890}
     - target: {fileID: 1435633644999899867, guid: 567347007592d07468c8d8aad25dcb19,
         type: 3}
       propertyPath: damegetext
@@ -1106,7 +1121,7 @@ PrefabInstance:
         type: 3}
       propertyPath: cameraManager
       value: 
-      objectReference: {fileID: 1388310083}
+      objectReference: {fileID: 0}
     - target: {fileID: 2407957913235363264, guid: 567347007592d07468c8d8aad25dcb19,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -1129,6 +1144,11 @@ PrefabInstance:
       objectReference: {fileID: 1940283756}
     - target: {fileID: 3103654202958394723, guid: 567347007592d07468c8d8aad25dcb19,
         type: 3}
+      propertyPath: timeText
+      value: 
+      objectReference: {fileID: 1349068890}
+    - target: {fileID: 3103654202958394723, guid: 567347007592d07468c8d8aad25dcb19,
+        type: 3}
       propertyPath: damegetext
       value: 
       objectReference: {fileID: 771972607}
@@ -1136,7 +1156,7 @@ PrefabInstance:
         type: 3}
       propertyPath: cameraManager
       value: 
-      objectReference: {fileID: 1388310083}
+      objectReference: {fileID: 0}
     - target: {fileID: 3808110960849004214, guid: 567347007592d07468c8d8aad25dcb19,
         type: 3}
       propertyPath: m_Name
@@ -1149,6 +1169,11 @@ PrefabInstance:
       objectReference: {fileID: 1940283756}
     - target: {fileID: 6530681076466333626, guid: 567347007592d07468c8d8aad25dcb19,
         type: 3}
+      propertyPath: timeText
+      value: 
+      objectReference: {fileID: 1349068890}
+    - target: {fileID: 6530681076466333626, guid: 567347007592d07468c8d8aad25dcb19,
+        type: 3}
       propertyPath: damegetext
       value: 
       objectReference: {fileID: 771972607}
@@ -1156,12 +1181,17 @@ PrefabInstance:
         type: 3}
       propertyPath: cameraManager
       value: 
-      objectReference: {fileID: 1388310083}
+      objectReference: {fileID: 0}
     - target: {fileID: 6953167321663598461, guid: 567347007592d07468c8d8aad25dcb19,
         type: 3}
       propertyPath: player
       value: 
       objectReference: {fileID: 1940283756}
+    - target: {fileID: 6953167321663598461, guid: 567347007592d07468c8d8aad25dcb19,
+        type: 3}
+      propertyPath: timeText
+      value: 
+      objectReference: {fileID: 1349068890}
     - target: {fileID: 6953167321663598461, guid: 567347007592d07468c8d8aad25dcb19,
         type: 3}
       propertyPath: damegetext
@@ -1171,12 +1201,17 @@ PrefabInstance:
         type: 3}
       propertyPath: cameraManager
       value: 
-      objectReference: {fileID: 1388310083}
+      objectReference: {fileID: 0}
     - target: {fileID: 8721076110584349702, guid: 567347007592d07468c8d8aad25dcb19,
         type: 3}
       propertyPath: player
       value: 
       objectReference: {fileID: 1940283756}
+    - target: {fileID: 8721076110584349702, guid: 567347007592d07468c8d8aad25dcb19,
+        type: 3}
+      propertyPath: timeText
+      value: 
+      objectReference: {fileID: 1349068890}
     - target: {fileID: 8721076110584349702, guid: 567347007592d07468c8d8aad25dcb19,
         type: 3}
       propertyPath: damegetext
@@ -1186,7 +1221,7 @@ PrefabInstance:
         type: 3}
       propertyPath: cameraManager
       value: 
-      objectReference: {fileID: 1388310083}
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -2176,7 +2211,7 @@ PrefabInstance:
         type: 3}
       propertyPath: cameraManager
       value: 
-      objectReference: {fileID: 1388310083}
+      objectReference: {fileID: 1960507846}
     - target: {fileID: 7509761686565556420, guid: a48a727c7065c3548ba40c77254c6b50,
         type: 3}
       propertyPath: scc
@@ -2201,7 +2236,7 @@ PrefabInstance:
         type: 3}
       propertyPath: cameraManager
       value: 
-      objectReference: {fileID: 1388310083}
+      objectReference: {fileID: 0}
     - target: {fileID: 7568597359185403882, guid: a48a727c7065c3548ba40c77254c6b50,
         type: 3}
       propertyPath: m_Name
@@ -2236,7 +2271,7 @@ PrefabInstance:
         type: 3}
       propertyPath: cameraManager
       value: 
-      objectReference: {fileID: 1388310083}
+      objectReference: {fileID: 1960507846}
     - target: {fileID: 8702844540050859848, guid: a48a727c7065c3548ba40c77254c6b50,
         type: 3}
       propertyPath: player
@@ -2260,6 +2295,7 @@ PrefabInstance:
     m_RemovedComponents:
     - {fileID: 2201494134820605207, guid: a48a727c7065c3548ba40c77254c6b50, type: 3}
     - {fileID: 7509761686565556420, guid: a48a727c7065c3548ba40c77254c6b50, type: 3}
+    - {fileID: 8376204789258582802, guid: a48a727c7065c3548ba40c77254c6b50, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents:
@@ -2536,18 +2572,6 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &1388310083 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 4673857090115547090, guid: 15b44400035ffbd4a8e523515c25e0cd,
-    type: 3}
-  m_PrefabInstance: {fileID: 7691997649379579761}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5544a84e1daa73c46b48dbc69f889ac4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &1420454281
@@ -3076,11 +3100,74 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   player: {fileID: 1940283756}
   scc: {fileID: 590965032}
-  cameraManager: {fileID: 1388310083}
+  cameraManager: {fileID: 1960507846}
   corePos: {fileID: 482613426}
   audioClip: {fileID: 8300000, guid: 764738ae8d75d9147b796d9b85558d3d, type: 3}
   rot: {x: 0, y: 0, z: 0, w: 0}
   speed: 300
+--- !u!1 &1960507845
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1960507847}
+  - component: {fileID: 1960507846}
+  m_Layer: 0
+  m_Name: GameObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1960507846
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1960507845}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5544a84e1daa73c46b48dbc69f889ac4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  player: {fileID: 1940283756}
+  enemy: {fileID: 7960315578906518100, guid: 8d293bab74173f64c887a5e2071ba933, type: 3}
+  skyEnemy:
+  - {fileID: 472213360}
+  - {fileID: 1095639180}
+  - {fileID: 924760560}
+  - {fileID: 2100763879}
+  - {fileID: 958728778}
+  - {fileID: 745232818}
+  - {fileID: 145250676}
+  player_obj: {fileID: 1321993647}
+  enemy_obj: {fileID: 814963462}
+  tipsTextKey: {fileID: 1628923374}
+  tipsText: {fileID: 130311568}
+  MissionText: {fileID: 1499612098}
+  clearText: {fileID: 1087408237}
+  gameOverText: {fileID: 625446250}
+  timeText: {fileID: 1349068890}
+  countdown: 60
+--- !u!4 &1960507847
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1960507845}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1982001576 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 2572050229066182967, guid: a48a727c7065c3548ba40c77254c6b50,
@@ -4173,6 +4260,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 3546943823860306184, guid: 15b44400035ffbd4a8e523515c25e0cd,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 4673857090115547090, guid: 15b44400035ffbd4a8e523515c25e0cd,
         type: 3}
       propertyPath: enemy
@@ -4366,7 +4458,8 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 4673857090115547090, guid: 15b44400035ffbd4a8e523515c25e0cd, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents:
@@ -4739,3 +4832,4 @@ SceneRoots:
   - {fileID: 443814305}
   - {fileID: 1283255678}
   - {fileID: 5015860557482486065}
+  - {fileID: 1960507847}

--- a/Assets/Scripts/CameraManager.cs
+++ b/Assets/Scripts/CameraManager.cs
@@ -43,7 +43,8 @@ public class CameraManager : MonoBehaviour
         tipsText.SetActive(true);//Tipsの表示
         Time.timeScale = 0.0f;//ゲーム停止
         TipsTextSeting();//テキストの設定
-        MissionTextSeting();//テキストの設定
+        //MissionTextSeting();//テキストの設定
+        MissionText.enabled = false;//ミッションテキストの非表示
     }
 
     // Update is called once per frame
@@ -55,9 +56,6 @@ public class CameraManager : MonoBehaviour
             //tipsTextKeyが表示中の場合
             if (player.hp >= 0 && tipsflg == false)
                 TipsTextManager();//TipsTextManagerの呼び出し
-            //playerが非表示の場合
-            if (player.hp == 0)
-                GameOverManager();
             //enemyが非表示の場合
             if (!enemy_obj.activeInHierarchy)
             {
@@ -77,12 +75,6 @@ public class CameraManager : MonoBehaviour
             if (player.hp >= 0 && tipsflg == false)
                 TipsTextManager();//TipsTextManagerの呼び出し
             TimeManager();//TimeManagerの呼び出し
-            //playerが非表示の場合
-            if (!player_obj.activeInHierarchy)
-            {
-                GameOverManager();
-                timeText.gameObject.SetActive(false);//timeテキスト非表示
-            }
             if (tipsflg == true)
             {
                 tipsTextKey.gameObject.SetActive(false);//tipsTextKey非表示

--- a/Assets/Scripts/DeathAreaManager.cs
+++ b/Assets/Scripts/DeathAreaManager.cs
@@ -9,7 +9,7 @@ using UnityEngine.UI;//テキスト表示で使用
 public class DeathAreaManager : MonoBehaviour
 {
     public PlayerController player;//player取得
-    public CameraManager cameraManager;//CameraManager参照
+    public Text timeText;//timetext取得
     public Text damegetext;//damegetext取得
     public GameObject DeathAreaEffect;//DeathAreaEffect取得
     private bool hpflg = false;//hp減少フラグ
@@ -34,8 +34,8 @@ public class DeathAreaManager : MonoBehaviour
     public void AreaScaleChange()
     {
         //カウントが0になった場合
-        if (cameraManager.timeText.text == "制限時間 残り30秒" && 
-            cameraManager.timeText.text != "制限時間 残り0秒" &&
+        if (timeText.text == "制限時間 残り30秒" && 
+            timeText.text != "制限時間 残り0秒" &&
             trSChangeflg == false)
         {
             trSChangeflg = true;

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -93,11 +93,9 @@ public class PlayerController : MonoBehaviour
         //クリア時のプレイヤーオブジェクト固定させるための処理
         //現状:Scene3、Scene4はPrefab化したエネミーを格納→それ以外は処理は通る
         if(!enemy.gameObject.activeSelf && hp >= 0)
-        {
             //クリア時処理-------------------------------------------------
             //GravityAttractor.csのAttract関数処理
             attractor.Attract(mytransform, myrb);//自身のtransformとrigidbodyの情報を渡す
-        }
     }
 
     /// <summary>


### PR DESCRIPTION
ミッションテキストを非表示に変更。
CameraManagerの一部のゲームオーバー処理の削除。
→PlayerController.cs内での処理と一致した内容のため（PlayerController.csの内容の方が優先されると判断）